### PR TITLE
Feature: Add Bug Report Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,61 @@
+name: 'Bug report'
+description: 'Create a report to help us improve'
+labels: ['bug']
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for taking the time to fill out this bug report!
+
+  - type: textarea
+    id: bug-description
+    attributes:
+      label: 'Describe the bug'
+      description: 'A clear and concise description of what the bug is.'
+    validations:
+      required: true
+
+  - type: textarea
+    id: to-reproduce
+    attributes:
+      label: 'To Reproduce'
+      description: 'Steps to reproduce the behavior:'
+      placeholder: |
+        1. Go to '...'
+        2. Click on '....'
+        3. Scroll down to '....'
+        4. See error
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected-behavior
+    attributes:
+      label: 'Expected behavior'
+      description: 'A clear and concise description of what you expected to happen.'
+    validations:
+      required: true
+
+  - type: textarea
+    id: screenshots
+    attributes:
+      label: 'Screenshots'
+      description: 'If applicable, add screenshots to help explain your problem.'
+
+  - type: checkboxes
+    id: os
+    attributes:
+      label: 'OS'
+      description: 'What operating systems are you using?'
+      options:
+        - label: 'Windows'
+        - label: 'macOS'
+        - label: 'Linux'
+        - label: 'iOS'
+        - label: 'Android'
+
+  - type: textarea
+    id: additional-context
+    attributes:
+      label: 'Additional context'
+      description: 'Add any other context about the problem here.'


### PR DESCRIPTION
## Description

Currently, the repository lacks a standardized process for submitting bug reports, which can lead to incomplete or inconsistent information from users. This makes it difficult and time-consuming for the development team to triage and reproduce issues.

This Pull Request introduces a new GitHub Issue template (bug_report.yml) to formalize the bug submission process. By providing a structured form, we can ensure that all essential information—such as reproduction steps, expected behavior, and environment details—is captured consistently, streamlining the entire bug-fixing workflow.

## Changes Made

* Added a new issue template file at `.github/ISSUE_TEMPLATE/bug_report.yml`.
* Defined a form-based template with dedicated fields for a description, reproduction steps, expected 
 behavior, OS selection, and screenshots.
* Initially configured the OS selector as a dropdown and later updated it to use checkboxes to allow for more 
 flexible environment reporting.
     
## Related Issue

Closes #3

## How to Verify
  
 Verify File Location and Content:
   * In the "Files changed" tab of this Pull Request, confirm that a new file exists at the correct path: 
     `.github/ISSUE_TEMPLATE/bug_report.yml`.
   * Review the raw content of the `bug_report.yml` file to ensure the YAML syntax is valid and that it 
     correctly defines the form fields (e.g., type, id, attributes) as intended for the bug report.
         
## Screenshots

N/A